### PR TITLE
Create iNumberic.js

### DIFF
--- a/iNumberic.js
+++ b/iNumberic.js
@@ -1,0 +1,30 @@
+// incase isNaN() can't be used, this is the program to help:
+function IsNumeric(input)
+{
+    return (input - 0) == input && (''+input).trim().length > 0;
+}
+
+
+
+//Test case
+01. IsNumeric('-1')      => true
+02. IsNumeric('-1.5')    => true
+03. IsNumeric('0')       => true
+04. IsNumeric('0.42')    => true
+05. IsNumeric('.42')     => true
+06. IsNumeric('99,999')  => false
+07. IsNumeric('0x89f')   => false
+08. IsNumeric('#abcdef') => false
+09. IsNumeric('1.2.3')   => false
+10. IsNumeric('')        => false
+11. IsNumeric('blah')    => false
+// Whitespace strings:
+12. IsNumeric(' ')    == true;
+13. IsNumeric('\t\t') == true;
+14. IsNumeric('\n\r') == true;
+
+// Number literals:
+15. IsNumeric(-1)  == false;
+16. IsNumeric(0)   == false;
+17. IsNumeric(1.1) == false;
+18. IsNumeric(8e5) == false;


### PR DESCRIPTION
The (input - 0) expression forces JavaScript to do type coercion on your input value; it must first be interpreted as a number for the subtraction operation. If that conversion to a number fails, the expression will result in NaN. This numeric result is then compared to the original value you passed in. Since the left hand side is now numeric, type coercion is again used. Now that the input from both sides was coerced to the same type from the same original value, you would think they should always be the same (always true). However, there's a special rule that says NaN is never equal to NaN, and so a value that can't be converted to a number (and only values that cannot be converted to numbers) will result in false.

The check on the length is for a special case involving empty strings. Also note that it falls down on your 0x89f test, but that's because in many environments that's an okay way to define a number literal. If you want to catch that specific scenario you could add an additional check. Even better, if that's your reason for not using isNaN() then just wrap your own function around isNaN() that can also do the additional check.